### PR TITLE
Faster Docker Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.4.0
 RUN apt-get update -qq
 RUN gem update bundler
 RUN mkdir /simple_jsonapi_client

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,5 @@ RUN apt-get update -qq
 RUN gem update bundler
 RUN mkdir /simple_jsonapi_client
 WORKDIR /simple_jsonapi_client
-ADD Gemfile /simple_jsonapi_client/Gemfile
-ADD simple_jsonapi_client.gemspec /simple_jsonapi_client/simple_jsonapi_client.gemspec
-ADD . /simple_jsonapi_client
+ADD . .
 RUN bundle install

--- a/lib/simple_jsonapi_client/version.rb
+++ b/lib/simple_jsonapi_client/version.rb
@@ -1,3 +1,3 @@
 module SimpleJSONAPIClient
-  VERSION = "0.1.1"
+  VERSION = "0.2.1"
 end

--- a/spec/jsonapi_app/Dockerfile
+++ b/spec/jsonapi_app/Dockerfile
@@ -5,5 +5,5 @@ RUN mkdir /jsonapi_app
 WORKDIR /jsonapi_app
 ADD Gemfile /jsonapi_app/Gemfile
 ADD Gemfile.lock /jsonapi_app/Gemfile.lock
-ADD . /jsonapi_app
 RUN bundle install
+ADD . /jsonapi_app


### PR DESCRIPTION
Using the same base image, and reordering the app Dockerfile to take better advantage of the build cache.