### PR TITLE
Actually put Array at the bottom of the list for method delegation

### DIFF
--- a/lib/simple_jsonapi_client/redirection/fetch_all.rb
+++ b/lib/simple_jsonapi_client/redirection/fetch_all.rb
@@ -3,9 +3,9 @@ require 'simple_jsonapi_client/redirection/proxy'
 module SimpleJSONAPIClient
   module Redirection
     class FetchAll < ::SimpleJSONAPIClient::Redirection::Proxy
-      def_delegators :internal_object, *(Array.instance_methods(false) - instance_methods)
       def_delegators :internal_enumerator, *(Enumerator.instance_methods(false) - instance_methods)
       def_delegators :internal_enumerator, *(Enumerable.instance_methods(false) - instance_methods)
+      def_delegators :internal_object, :size, *(Array.instance_methods(false) - instance_methods)
 
       def initialize(base_opts, &operation)
         @base_opts = base_opts

--- a/lib/simple_jsonapi_client/version.rb
+++ b/lib/simple_jsonapi_client/version.rb
@@ -1,3 +1,3 @@
 module SimpleJSONAPIClient
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/spec/integration/read_spec.rb
+++ b/spec/integration/read_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe 'reading models' do
       let(:returned_authors) { fetch_authors(includes: ['posts.comments']) }
 
       it 'uses includes to avoid new HTTP requests' do
-        returned_authors.first
+        author = returned_authors.first
         expect(connection).not_to receive(:get)
-        expect(returned_authors.first.posts.first.comments.first.text).to eq(comments.first.text)
+        expect(author.posts.first.comments.first.text).to eq(comments.first.text)
       end
     end
   end


### PR DESCRIPTION
We want Enumerable, not Array, to be hit.