### PR TITLE
Install the version of bundler that was used to create Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4.0
 RUN apt-get update -qq
-RUN gem update bundler
+RUN gem install bundler -v 1.15.3
 RUN mkdir /simple_jsonapi_client
 WORKDIR /simple_jsonapi_client
 ADD . .

--- a/spec/jsonapi_app/Dockerfile
+++ b/spec/jsonapi_app/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4.0
 RUN apt-get update -qq
-RUN gem update bundler
+RUN gem install bundler -v 1.15.3
 RUN mkdir /jsonapi_app
 WORKDIR /jsonapi_app
 ADD Gemfile /jsonapi_app/Gemfile


### PR DESCRIPTION
I ran into an issue trying to get the dev environment setup and I see that TravisCI is reporting a similar issue for the dependency removal branch: https://travis-ci.org/amcaplan/simple_jsonapi_client/builds/571332659

The problem is that the `gem update bundler` command is installing bundler 2 which doesn't let you run `bundle install` against Gemfile.lock files built with pre-2.x versions. You could probably update the build and Gemfiles to use 2.x but for now it's easier just to install the version that was used to create Gemfile.lock in the first place.