### PR TITLE
Bump Faraday dependencies to 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ services:
   - docker
 before_install:
   - bin/setup
-  - gem update bundler
+  - gem install -v 2.2 bundler -N
 script:
   - rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ services:
 before_install:
   - bin/setup
   - gem install -v 2.2 bundler -N
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 script:
   - rake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ruby:2.4.0
+FROM ruby:2.6.6
 RUN apt-get update -qq
-RUN gem update bundler
-ENV BUNDLER_VERSION=2.0.2
+RUN gem update --system
+RUN gem install -v 2.2.3 bundler -N
+ENV BUNDLER_VERSION=2.2
 RUN mkdir /simple_jsonapi_client
 WORKDIR /simple_jsonapi_client
 ADD . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       API_PORT: 3001
   jsonapi_app_spec:
     build: ./spec/jsonapi_app
-    entrypoint: bin/wait_for_it db:5432 -t 30 --
+    entrypoint: bin/wait_for_it db:5432 -t 60 --
     # volumes:
       # - ./spec/jsonapi_app:/jsonapi_app
     command: bundle exec rails s -p 3001 -b '0.0.0.0'
@@ -40,7 +40,7 @@ services:
       API_PORT: 3002
   jsonapi_app_console:
     build: ./spec/jsonapi_app
-    entrypoint: bin/wait_for_it db:5432 -t 30 --
+    entrypoint: bin/wait_for_it db:5432 -t 60 --
     # volumes:
       # - ./spec/jsonapi_app:/jsonapi_app
     command: bundle exec rails s -p 3002 -b '0.0.0.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,8 @@ services:
   jsonapi_app_spec:
     build: ./spec/jsonapi_app
     entrypoint: bin/wait_for_it db:5432 -t 30 --
-    volumes:
-      - ./spec/jsonapi_app:/jsonapi_app
-      - /jsonapi_app/tmp/
+    # volumes:
+      # - ./spec/jsonapi_app:/jsonapi_app
     command: bundle exec rails s -p 3001 -b '0.0.0.0'
     ports:
       - "3001:3001"
@@ -40,9 +39,8 @@ services:
   jsonapi_app_console:
     build: ./spec/jsonapi_app
     entrypoint: bin/wait_for_it db:5432 -t 30 --
-    volumes:
-      - ./spec/jsonapi_app:/jsonapi_app
-      - /jsonapi_app/tmp/
+    # volumes:
+      # - ./spec/jsonapi_app:/jsonapi_app
     command: bundle exec rails s -p 3002 -b '0.0.0.0'
     ports:
       - "3002:3002"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   db:
     image: postgres
+    ports:
+      - "5432:5432"
   spec:
     build: .
     entrypoint: bin/wait_for_it jsonapi_app_spec:3001 -t 30 --

--- a/lib/simple_jsonapi_client/version.rb
+++ b/lib/simple_jsonapi_client/version.rb
@@ -1,3 +1,3 @@
 module SimpleJSONAPIClient
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end

--- a/simple_jsonapi_client.gemspec
+++ b/simple_jsonapi_client.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "~> 0.12"
-  spec.add_dependency "faraday_middleware", "~> 0.11"
+  spec.add_dependency "faraday", ">= 0.12", "< 2.0"
+  spec.add_dependency "faraday_middleware", "> 0.11", "< 2.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0"

--- a/spec/jsonapi_app/.dockerignore
+++ b/spec/jsonapi_app/.dockerignore
@@ -1,0 +1,1 @@
+tmp/pids/server.pid

--- a/spec/jsonapi_app/Dockerfile
+++ b/spec/jsonapi_app/Dockerfile
@@ -1,6 +1,7 @@
-FROM ruby:2.4.0
+FROM ruby:2.6.6
 RUN apt-get update -qq
-RUN gem update bundler
+RUN gem update --system
+RUN gem install -v 2.2.3 bundler -N
 RUN mkdir /jsonapi_app
 WORKDIR /jsonapi_app
 ADD Gemfile /jsonapi_app/Gemfile

--- a/spec/jsonapi_app/Gemfile.lock
+++ b/spec/jsonapi_app/Gemfile.lock
@@ -128,4 +128,4 @@ DEPENDENCIES
   rails (~> 5.0.1)
 
 BUNDLED WITH
-   1.15.3
+   2.2.3


### PR DESCRIPTION
Allow older versions (since we assume they work), but also allow newer versions since specs pass.

Solves https://github.com/amcaplan/simple_jsonapi_client/issues/24