### PR TITLE
Let docker-compose read the password for postgres from .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=yoursecrethere
+# You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all connections
+# without a password. This is *not* recommended.
+#  POSTGRES_HOST_AUTH_METHOD=trust"

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# .env can contain secrets.
+.env

--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ Or install it yourself as:
 
 You must have [Docker](https://docker.com) and [Docker Compose](https://docs.docker.com/compose/) installed to run the tests and use the built-in development utilities.
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment, and `bin/rails` to interact with the Rails app in `spec/jsonapi_app` that is provided for local development and testing.
+After checking out the repo, set-up env vars by copying `.env.example` to `.env` and changing the password.
+Then run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment, and `bin/rails` to interact with the Rails app in `spec/jsonapi_app` that is provided for local development and testing.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres
     ports:
       - "5432:5432"
+    env_file:
+      - .env
   spec:
     build: .
     entrypoint: bin/wait_for_it jsonapi_app_spec:3001 -t 30 --
@@ -15,6 +17,8 @@ services:
     environment:
       API_URL: jsonapi_app_spec
       API_PORT: 3001
+    env_file:
+      - .env
   jsonapi_app_spec:
     build: ./spec/jsonapi_app
     entrypoint: bin/wait_for_it db:5432 -t 60 --
@@ -25,6 +29,8 @@ services:
       - "3001:3001"
     environment:
       API_PORT: 3001
+    env_file:
+      - .env
     depends_on:
       - db
   console:
@@ -38,6 +44,8 @@ services:
     environment:
       API_URL: jsonapi_app_console
       API_PORT: 3002
+    env_file:
+      - .env
   jsonapi_app_console:
     build: ./spec/jsonapi_app
     entrypoint: bin/wait_for_it db:5432 -t 60 --
@@ -48,3 +56,5 @@ services:
       - "3002:3002"
     depends_on:
       - db
+    env_file:
+      - .env

--- a/spec/jsonapi_app/config/database.yml
+++ b/spec/jsonapi_app/config/database.yml
@@ -3,7 +3,7 @@ default: &default
   encoding: unicode
   host: db
   username: postgres
-  password:
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
   pool: 5
 
 development:


### PR DESCRIPTION
Without this password, docker compose would fail to launch the database,
as the POSTGRES_PASSWORD is a required env var for this container/image.

This commit adds an .env template file, ensures the .env is ignored and
therefore not accidentally committed. And adds instructions to the
README.

The error from postgres is:

Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html