### PR TITLE
Allow the ID to be set on creating resources.

### DIFF
--- a/lib/simple_jsonapi_client/base.rb
+++ b/lib/simple_jsonapi_client/base.rb
@@ -117,13 +117,14 @@ module SimpleJSONAPIClient
       end
 
       def create_request(connection:,
+                         id: nil,
                          url_opts: {},
                          url: self::COLLECTION_URL % url_opts,
                          attributes: {},
                          relationships: {},
                          **attrs)
         attributes, relationships = extract_attrs(attrs, attributes, relationships)
-        body = template(attributes: attributes, relationships: relationships)
+        body = template(id: id, attributes: attributes, relationships: relationships)
         connection.post(url, body)
       end
 

--- a/spec/integration/create_spec.rb
+++ b/spec/integration/create_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe 'creating models' do
     )
   end
 
+  def create_author_with(id:, name:)
+    JSONAPIAppClient::Author.create(
+      id: id,
+      name: name,
+      connection: connection
+    )
+  end
+
   def fetch_post(id)
     JSONAPIAppClient::Post.fetch(
       connection: connection,
@@ -51,6 +59,14 @@ RSpec.describe 'creating models' do
         expect(author.name).to eq(name)
         reloaded_author = fetch_author(author.id)
         expect(reloaded_author.name).to eq(name)
+      end
+
+      it 'creates the Author with the provided ID' do
+        # Generate a high, random ID. In production implementation it should be
+        # a UUID or other guaranteed unique id.
+        id = 1000 + Random.rand(99999) 
+        create_author_with(id: id, name: name)
+        expect(fetch_author(id).name).to eq(name)
       end
     end
 

--- a/spec/jsonapi_app/app/resources/author_resource.rb
+++ b/spec/jsonapi_app/app/resources/author_resource.rb
@@ -4,4 +4,8 @@ class AuthorResource < JSONAPI::Resource
 
   has_many :posts
   has_many :comments
+
+  def self.creatable_fields(_context = nil)
+    super + [:id]
+  end
 end


### PR DESCRIPTION
This closes #33.

As requested in #33, this includes a spec to test this. We only test it on Author and not Post, since that would be exactly the same. The rails app needed a little tweak, since, by default, jsonapi-resources does not allow setting an ID. It has an override for this, which is implemented for the AuthorResource in that app.

Do you want a spec to prove that settings IDS on relations as well works?

Do you prefer some additions to the README or some other documentation? And if so, where?