### PR TITLE
Simple change to allow it to be used with Ruby3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3'
 services:
   db:
     image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5432:5432"
   spec:

--- a/lib/simple_jsonapi_client/base.rb
+++ b/lib/simple_jsonapi_client/base.rb
@@ -110,7 +110,7 @@ module SimpleJSONAPIClient
       end
 
       def operation(request_method, response_type, opts)
-        response = send(request_method, opts)
+        response = send(request_method, **opts)
         handling_error(response) do
           send(:"interpret_#{response_type}_response", response, opts[:connection])
         end


### PR DESCRIPTION
Trying to get my project upgraded to Ruby3, and while there has been some tweaks to make it closer, I believe there are still some hidden ones.
This PR simply adds another splat in the low level send of an operation, which currently fails under Ruby3.

Note: I've also changed the `POSTGRES_HOST_AUTH_METHOD: trust` to the docker-compose, as trying to setup the tests was complaining and I think it's probably a good idea to make the process smoother. Can back that out, if you don't think it is.